### PR TITLE
Remove unnecessary `+` in nested-python output

### DIFF
--- a/abnf_to_regexp/nested_python.py
+++ b/abnf_to_regexp/nested_python.py
@@ -471,7 +471,7 @@ def represent(table: "collections.OrderedDict[str, Element]") -> str:
 
             for line_i, line in enumerate(lines_of_segments):
                 if line_i > 0:
-                    writer.write(" +\n")
+                    writer.write("\n")
 
                 writer.write(" " * 4)
 

--- a/tests/data/nested-python/rfc3987/expected.py
+++ b/tests/data/nested-python/rfc3987/expected.py
@@ -4,11 +4,11 @@ pct_encoded = '%[0-9A-Fa-f][0-9A-Fa-f]'
 sub_delims = "[!$&'()*+,;=]"
 iprivate = '[\\ue000-\\uf8ff\\uf0000-\\uffffd\\u100000-\\u10fffd]'
 ucschar = (
-    '[\\xa0-\\ud7ff\\uf900-\\ufdcf\\ufdf0-\\uffef\\u10000-\\u1fffd' +
-    '\\u20000-\\u2fffd\\u30000-\\u3fffd\\u40000-\\u4fffd' +
-    '\\u50000-\\u5fffd\\u60000-\\u6fffd\\u70000-\\u7fffd' +
-    '\\u80000-\\u8fffd\\u90000-\\u9fffd\\ua0000-\\uafffd' +
-    '\\ub0000-\\ubfffd\\uc0000-\\ucfffd\\ud0000-\\udfffd' +
+    '[\\xa0-\\ud7ff\\uf900-\\ufdcf\\ufdf0-\\uffef\\u10000-\\u1fffd'
+    '\\u20000-\\u2fffd\\u30000-\\u3fffd\\u40000-\\u4fffd'
+    '\\u50000-\\u5fffd\\u60000-\\u6fffd\\u70000-\\u7fffd'
+    '\\u80000-\\u8fffd\\u90000-\\u9fffd\\ua0000-\\uafffd'
+    '\\ub0000-\\ubfffd\\uc0000-\\ucfffd\\ud0000-\\udfffd'
     '\\ue1000-\\uefffd]'
 )
 unreserved = '[a-zA-Z0-9\\-._~]'
@@ -25,10 +25,10 @@ ireg_name = f'({iunreserved}|{pct_encoded}|{sub_delims})*'
 isegment_nz_nc = f'({iunreserved}|{pct_encoded}|{sub_delims}|@){{1,}}'
 ipchar = f'({iunreserved}|{pct_encoded}|{sub_delims}|[:@])'
 ipv6address = (
-    f'(({h16}:){{6,6}}{ls32}|::({h16}:){{5,5}}{ls32}|({h16})?::({h16}' +
-    f':){{4,4}}{ls32}|(({h16}:)?{h16})?::({h16}:){{3,3}}{ls32}|(({h16}' +
-    f':){{2}}{h16})?::({h16}:){{2,2}}{ls32}|(({h16}:){{3}}{h16})?::{h16}:' +
-    f'{ls32}|(({h16}:){{4}}{h16})?::{ls32}|(({h16}:){{5}}{h16})?::{h16}|' +
+    f'(({h16}:){{6,6}}{ls32}|::({h16}:){{5,5}}{ls32}|({h16})?::({h16}'
+    f':){{4,4}}{ls32}|(({h16}:)?{h16})?::({h16}:){{3,3}}{ls32}|(({h16}'
+    f':){{2}}{h16})?::({h16}:){{2,2}}{ls32}|(({h16}:){{3}}{h16})?::{h16}:'
+    f'{ls32}|(({h16}:){{4}}{h16})?::{ls32}|(({h16}:){{5}}{h16})?::{h16}|'
     f'(({h16}:){{6}}{h16})?::)'
 )
 iquery = f'({ipchar}|{iprivate}|[/?])*'
@@ -43,16 +43,16 @@ ipath_abempty = f'(/{isegment})*'
 ipath_noscheme = f'{isegment_nz_nc}(/{isegment})*'
 ihost = f'({ip_literal}|{ipv4address}|{ireg_name})'
 ipath = (
-    f'({ipath_abempty}|{ipath_absolute}|{ipath_noscheme}|' +
+    f'({ipath_abempty}|{ipath_absolute}|{ipath_noscheme}|'
     f'{ipath_rootless}|{ipath_empty})'
 )
 iauthority = f'({iuserinfo}@)?{ihost}(:{port})?'
 ihier_part = (
-    f'(//{iauthority}{ipath_abempty}|{ipath_absolute}|' +
+    f'(//{iauthority}{ipath_abempty}|{ipath_absolute}|'
     f'{ipath_rootless}|{ipath_empty})'
 )
 irelative_part = (
-    f'(//{iauthority}{ipath_abempty}|{ipath_absolute}|' +
+    f'(//{iauthority}{ipath_abempty}|{ipath_absolute}|'
     f'{ipath_noscheme}|{ipath_empty})'
 )
 irelative_ref = f'{irelative_part}(\\?{iquery})?(\\#{ifragment})?'


### PR DESCRIPTION
The addition (`+`) is unnecessary for string concatenation when the
strings are listed in the parentheses. Removing `+`'s improves the
readability.