### PR TITLE
Test for BCP47 language tag

### DIFF
--- a/abnf_to_regexp/nested_python.py
+++ b/abnf_to_regexp/nested_python.py
@@ -341,8 +341,17 @@ class _Representer(Visitor):
         self.visit(element.element)
         self.stream.write_text(")")
 
+    _NO_NEED_TO_ESCAPE_RE = re.compile(r"[a-zA-Z_0-9\-]*")
+
     def visit_literal(self, element: Literal) -> None:
-        escaped_value = re.escape(element.value)
+        # ``re.escape`` is a bit too conservative and produces unreadable regular
+        # expressions. To make the expressions more readable, we avoid escaping
+        # the cases where we are sure no escapes are necessary.
+        if _Representer._NO_NEED_TO_ESCAPE_RE.fullmatch(element.value):
+            escaped_value = element.value
+        else:
+            escaped_value = re.escape(element.value)
+
         assert isinstance(escaped_value, str)
 
         self.stream.write_text(escaped_value)

--- a/test_data/nested-python/bcp47/expected.py
+++ b/test_data/nested-python/bcp47/expected.py
@@ -1,0 +1,24 @@
+alphanum = '[a-zA-Z0-9]'
+singleton = '[0-9A-WY-Za-wy-z]'
+extension = f'{singleton}(-({alphanum}){{2,8}}){{1,}}'
+extlang = '[a-zA-Z]{3,3}(-[a-zA-Z]{3,3}){2}'
+irregular = (
+    '(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|'
+    'i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|'
+    'i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)'
+)
+regular = (
+    '(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|'
+    'zh-min|zh-min-nan|zh-xiang)'
+)
+grandfathered = f'({irregular}|{regular})'
+language = f'([a-zA-Z]{{2,3}}(-{extlang})?|[a-zA-Z]{{4,4}}|[a-zA-Z]{{5,8}})'
+script = '[a-zA-Z]{4,4}'
+region = '([a-zA-Z]{2,2}|[0-9]{3,3})'
+variant = f'(({alphanum}){{5,8}}|[0-9]({alphanum}){{3,3}})'
+privateuse = f'[xX](-({alphanum}){{1,8}}){{1,}}'
+langtag = (
+    f'{language}(-{script})?(-{region})?(-{variant})*(-{extension})*(-'
+    f'{privateuse})?'
+)
+language_tag = f'({langtag}|{privateuse}|{grandfathered})'

--- a/test_data/nested-python/bcp47/grammar.abnf
+++ b/test_data/nested-python/bcp47/grammar.abnf
@@ -1,0 +1,81 @@
+; From: https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+; Abstract
+; 
+;    This document describes the structure, content, construction, and
+;    semantics of language tags for use in cases where it is desirable to
+;    indicate the language used in an information object.  It also
+;    describes how to register values for use in language tags and the
+;    creation of user-defined extensions for private interchange.
+
+Language-Tag  = langtag             ; normal language tags
+           / privateuse          ; private use tag
+           / grandfathered       ; grandfathered tags
+
+langtag       = language
+             ["-" script]
+             ["-" region]
+             *("-" variant)
+             *("-" extension)
+             ["-" privateuse]
+
+language      = 2*3ALPHA            ; shortest ISO 639 code
+             ["-" extlang]       ; sometimes followed by
+                                 ; extended language subtags
+           / 4ALPHA              ; or reserved for future use
+           / 5*8ALPHA            ; or registered language subtag
+
+extlang       = 3ALPHA              ; selected ISO 639 codes
+             *2("-" 3ALPHA)      ; permanently reserved
+
+script        = 4ALPHA              ; ISO 15924 code
+
+region        = 2ALPHA              ; ISO 3166-1 code
+           / 3DIGIT              ; UN M.49 code
+
+variant       = 5*8alphanum         ; registered variants
+           / (DIGIT 3alphanum)
+
+extension     = singleton 1*("-" (2*8alphanum))
+
+                                 ; Single alphanumerics
+                                 ; "x" reserved for private use
+singleton     = DIGIT               ; 0 - 9
+           / %x41-57             ; A - W
+           / %x59-5A             ; Y - Z
+           / %x61-77             ; a - w
+           / %x79-7A             ; y - z
+
+privateuse    = "x" 1*("-" (1*8alphanum))
+
+grandfathered = irregular           ; non-redundant tags registered
+           / regular             ; during the RFC 3066 era
+
+irregular     = "en-GB-oed"         ; irregular tags do not match
+           / "i-ami"             ; the 'langtag' production and
+           / "i-bnn"             ; would not otherwise be
+           / "i-default"         ; considered 'well-formed'
+           / "i-enochian"        ; These tags are all valid,
+           / "i-hak"             ; but most are deprecated
+           / "i-klingon"         ; in favor of more modern
+           / "i-lux"             ; subtags or subtag
+           / "i-mingo"           ; combination
+          / "i-navajo"
+           / "i-pwn"
+           / "i-tao"
+           / "i-tay"
+           / "i-tsu"
+           / "sgn-BE-FR"
+           / "sgn-BE-NL"
+           / "sgn-CH-DE"
+
+regular       = "art-lojban"        ; these tags match the 'langtag'
+           / "cel-gaulish"       ; production, but their subtags
+           / "no-bok"            ; are not extended language
+           / "no-nyn"            ; or variant subtags: their meaning
+           / "zh-guoyu"          ; is defined by their registration
+           / "zh-hakka"          ; and all of these are deprecated
+           / "zh-min"            ; in favor of a more modern
+           / "zh-min-nan"        ; subtag or sequence of subtags
+           / "zh-xiang"
+
+alphanum      = (ALPHA / DIGIT)     ; letters and numbers

--- a/test_data/nested-python/rfc3339/expected.py
+++ b/test_data/nested-python/rfc3339/expected.py
@@ -1,7 +1,7 @@
 date_fullyear = '[0-9]{4,4}'
 date_mday = '[0-9]{2,2}'
 date_month = '[0-9]{2,2}'
-full_date = f'{date_fullyear}\\-{date_month}\\-{date_mday}'
+full_date = f'{date_fullyear}-{date_month}-{date_mday}'
 time_hour = '[0-9]{2,2}'
 time_minute = '[0-9]{2,2}'
 time_second = '[0-9]{2,2}'


### PR DESCRIPTION
This patch adds a test for BCP47 language tag. It revealed that we
escaped dashes in literal which produced unreadable expressions.

Therefore, this patch skips escaping the most obvious case of
alphanumeric literals with dashes and underscores.