### PR TITLE
Include `tests` in pylint

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -99,7 +99,7 @@ def main() -> int:
     if Step.PYLINT in selects and Step.PYLINT not in skips:
         # fmt: off
         print("Pylint'ing...")
-        pylint_targets = ["abnf_to_regexp"]
+        pylint_targets = ["abnf_to_regexp", "tests"]
         subprocess.check_call(
             ["pylint", "--rcfile=pylint.rc"] + pylint_targets, cwd=str(repo_root)
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,6 @@
+# pylint: disable=missing-docstring
+# pylint: disable=no-self-use
+
 import io
 import os
 import pathlib
@@ -151,7 +154,7 @@ class TestAgainstRecordings(unittest.TestCase):
             expected_out_pth = case_dir / "expected.py"
 
             # Set to True if you are debugging or updating the tests
-            record = True  # TODO (mristin, 2022-04-1): undo
+            record = False
 
             if record:
                 expected_err_pth.write_text(stderr.getvalue(), encoding='utf-8')
@@ -178,7 +181,7 @@ class TestAgainstRecordings(unittest.TestCase):
                 code = stdout.getvalue().strip()
                 try:
                     compile(code, "<abnf-to-regexp-test>", mode='exec')
-                except Exception as err:
+                except Exception:
                     raise AssertionError(
                         f"Failed to compile code as in {expected_out_pth}:\n"
                         f"{code}"


### PR DESCRIPTION
We include `tests` module in pylint precommit check so that we do not
omit `TODO`'s in the future.