### PR TITLE
Add support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/check-on-pull-request.yml
+++ b/.github/workflows/check-on-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-on-push-to-main.yml
+++ b/.github/workflows/check-on-push-to-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@master

--- a/precommit.py
+++ b/precommit.py
@@ -154,16 +154,24 @@ def main() -> int:
         )
 
     if Step.CHECK_HELP_IN_README in selects and Step.CHECK_HELP_IN_README not in skips:
-        cmd = [sys.executable, "check_help_in_readme.py"]
-        if overwrite:
-            cmd.append("--overwrite")
+        if sys.version_info < (3, 10):
+            cmd = [sys.executable, "check_help_in_readme.py"]
+            if overwrite:
+                cmd.append("--overwrite")
 
-        if not overwrite:
-            print("Checking that --help's and the doc coincide...")
+            if not overwrite:
+                print("Checking that --help's and the doc coincide...")
+            else:
+                print("Overwriting the --help's in the doc...")
+
+            subprocess.check_call(cmd)
         else:
-            print("Overwriting the --help's in the doc...")
-
-        subprocess.check_call(cmd)
+            print(
+                f"Since Python 3.10 changed how the argparse renders the --help, "
+                f"we can compare --help only against Python <= 3.9. "
+                f"Hence we do not check whether the --help coincides with "
+                f"the readme on your version of Python ({sys.version})."
+            )
     else:
         print("Skipped checking that --help's and the doc coincide.")
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="abnf backus-naur convert regular expressions",


### PR DESCRIPTION
We include the Python versions 3.9 and 3.10 in the continous
integration.