### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ CHANGELOG
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+1.1.1 (2022-06-15)
+==================
+* Add support for Python 3.9 and 3.10 (#24)
+* Fix escaping for UTF-32 (#23)
+
 1.1.0 (2022-05-22)
 ==================
 * Add ``nested-in-python`` representation (#3)

--- a/abnf_to_regexp/__init__.py
+++ b/abnf_to_regexp/__init__.py
@@ -1,7 +1,7 @@
 """Convert ABNF grammars to Python regular expressions."""
 
 # Do not forget to update in setup.py!
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Marko Ristin"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name="abnf-to-regexp",
     # Don't forget to update the version in __init__.py!
-    version="1.1.0",
+    version="1.1.1",
     description="Convert ABNF grammars to Python regular expressions.",
     long_description=long_description,
     url="https://github.com/aas-core-works/abnf-to-regexp",


### PR DESCRIPTION
* Add support for Python 3.9 and 3.10 (#24)
* Fix escaping for UTF-32 (#23)