### PR TITLE
Fix and update `precommit.py`

### DIFF
--- a/abnf_to_regexp/abnf_transformation.py
+++ b/abnf_to_regexp/abnf_transformation.py
@@ -1,4 +1,5 @@
 """Provide building blocks for transformation of ABNF to something else."""
+
 import abc
 import bisect
 import itertools

--- a/abnf_to_regexp/base.py
+++ b/abnf_to_regexp/base.py
@@ -1,4 +1,5 @@
 """Provide base building blocks for the regular expressions."""
+
 import abc
 from typing import Iterable, Optional, Union, TypeVar, Generic
 

--- a/abnf_to_regexp/compression.py
+++ b/abnf_to_regexp/compression.py
@@ -1,4 +1,5 @@
 """Compress regular expressions to an equivalent shorter form."""
+
 from typing import List, Union
 
 import regex as re

--- a/abnf_to_regexp/nested_python.py
+++ b/abnf_to_regexp/nested_python.py
@@ -1,4 +1,5 @@
 """Translate an ABNF to a code snippet of Python."""
+
 import collections
 import enum
 import io

--- a/abnf_to_regexp/representation.py
+++ b/abnf_to_regexp/representation.py
@@ -1,4 +1,5 @@
 """Provide common functions for representing regular expressions."""
+
 import string
 
 

--- a/abnf_to_regexp/single_regexp.py
+++ b/abnf_to_regexp/single_regexp.py
@@ -1,4 +1,5 @@
 """Transform ABNF to a single regular expression."""
+
 from typing import Type, List
 
 import abnf

--- a/precommit.py
+++ b/precommit.py
@@ -80,10 +80,13 @@ def main() -> int:
         # fmt: on
 
         if overwrite:
-            subprocess.check_call(["black"] + black_targets, cwd=str(repo_root))
+            subprocess.check_call(
+                [sys.executable, "-m", "black"] + black_targets, cwd=str(repo_root)
+            )
         else:
             subprocess.check_call(
-                ["black", "--check"] + black_targets, cwd=str(repo_root)
+                [sys.executable, "-m", "black", "--check"] + black_targets,
+                cwd=str(repo_root),
             )
     else:
         print("Skipped black'ing.")
@@ -92,7 +95,13 @@ def main() -> int:
         print("Mypy'ing...")
         # fmt: off
         mypy_targets = ["abnf_to_regexp", "tests", "dev_scripts"]
-        subprocess.check_call(["mypy", "--strict"] + mypy_targets, cwd=str(repo_root))
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "mypy",
+                "--strict"
+             ] + mypy_targets, cwd=str(repo_root))
         # fmt: on
     else:
         print("Skipped mypy'ing.")
@@ -102,7 +111,12 @@ def main() -> int:
         print("Pylint'ing...")
         pylint_targets = ["abnf_to_regexp", "tests", "dev_scripts"]
         subprocess.check_call(
-            ["pylint", "--rcfile=pylint.rc"] + pylint_targets, cwd=str(repo_root)
+            [
+                sys.executable,
+                "-m",
+                "pylint",
+                "--rcfile=pylint.rc"
+            ] + pylint_targets, cwd=str(repo_root)
         )
         # fmt: on
     else:
@@ -116,6 +130,8 @@ def main() -> int:
         # fmt: off
         subprocess.check_call(
             [
+                sys.executable,
+                "-m",
                 "coverage", "run",
                 "--source", "abnf_to_regexp",
                 "-m", "unittest", "discover"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
+
 import os
 
 from setuptools import setup, find_packages
@@ -42,8 +43,8 @@ setup(
     # fmt: off
     extras_require={
         "dev": [
-            "black==22.3.0",
-            "mypy==0.812",
+            "black==24.3.0",
+            "mypy==1.9.0",
             "pylint==2.3.1",
             "pydocstyle>=2.1.1,<3",
             "coverage>=4.5.1,<5",


### PR DESCRIPTION
We need to use `sys.executable` to avoid problems when the script is run in an IDE, and the commands such as `black` or `mypy` are not available on the PATH.

At this occasion, we also update `black` and `mypy` to latest versions.