### PR TITLE
Fix check-help-in-readme in CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ For example, the alternations of character classes are taken together to form a 
 
 ``--help``
 ==========
-.. Help starts: abnf-to-regexp --help
+.. Help starts: python3 abnf_to_regexp/main.py --help
 .. code-block::
 
     usage: abnf-to-regexp [-h] -i INPUT [-o OUTPUT]
@@ -54,7 +54,7 @@ For example, the alternations of character classes are taken together to form a 
                             Output format; for example a single regular expression
                             or a code snippet
 
-.. Help ends: abnf-to-regexp --help
+.. Help ends: python3 abnf_to_regexp/main.py --help
 
 Example Conversion
 ==================

--- a/check_help_in_readme.py
+++ b/check_help_in_readme.py
@@ -79,6 +79,11 @@ def capture_output_lines(command: str) -> List[str]:
         # is not properly inherited.
         command_parts[0] = sys.executable
 
+    if not os.path.exists(command_parts[0]):
+        raise FileNotFoundError(
+            f"The python interpreter could not be found: {command_parts[0]}"
+        )
+
     proc = subprocess.Popen(
         command_parts,
         stdout=subprocess.PIPE,
@@ -197,8 +202,6 @@ def main() -> int:
             if error:
                 print(error, file=sys.stderr)
                 return -1
-
-    return 0
 
     return 0
 

--- a/precommit.py
+++ b/precommit.py
@@ -181,7 +181,7 @@ def main() -> int:
             else:
                 print("Overwriting the --help's in the doc...")
 
-            subprocess.check_call(cmd)
+            subprocess.check_call(cmd, cwd=str(repo_root))
         else:
             print(
                 f"Since Python 3.10 changed how the argparse renders the --help, "


### PR DESCRIPTION
On Windows, the virtual environment in PyCharm does not include the console commands provided in `setup.py`, so we have to update the check-help-in-readme script to invoke the Python interpreter on the command script instead of directly invoking it.