### PR TITLE
Discontinue Python 3.7 and include 3.11

### DIFF
--- a/.github/workflows/check-on-pull-request.yml
+++ b/.github/workflows/check-on-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-on-push-to-main.yml
+++ b/.github/workflows/check-on-push-to-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="abnf backus-naur convert regular expressions",


### PR DESCRIPTION
We discontinue Python 3.7 as we can not run `black` on it anymore.

We also include Python 3.11 in CI to support the more modern version.