### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ CHANGELOG
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+1.1.3 (2024-03-22)
+==================
+* Fix for the case no min. and only max. repetition (#34)
+* Discontinue Python 3.7 and include 3.11 (#33)
+
 1.1.2 (2022-09-28)
 ==================
 *  Upgrade to abnf 2.0.0 (#27)

--- a/abnf_to_regexp/__init__.py
+++ b/abnf_to_regexp/__init__.py
@@ -1,7 +1,7 @@
 """Convert ABNF grammars to Python regular expressions."""
 
 # Do not forget to update in setup.py!
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __author__ = "Marko Ristin"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name="abnf-to-regexp",
     # Don't forget to update the version in __init__.py!
-    version="1.1.2",
+    version="1.1.3",
     description="Convert ABNF grammars to Python regular expressions.",
     long_description=long_description,
     url="https://github.com/aas-core-works/abnf-to-regexp",


### PR DESCRIPTION
* Fix for the case no min. and only max. repetition (#34)
* Discontinue Python 3.7 and include 3.11 (#33)