### PR TITLE
Update coverage to latest version 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "mypy==1.9.0",
             "pylint==2.3.1",
             "pydocstyle>=2.1.1,<3",
-            "coverage>=4.5.1,<5",
+            "coverage>=7,<8",
             "docutils>=0.14,<1",
             "pygments>=2,<3",
         ],


### PR DESCRIPTION
We need to update the coverage so that coveralls.io can send the data to coveralls.io platform. Before, coveralls.io relied on an import from coverage that broke it in earlier versions.