### PR TITLE
Fix default for format argument

### DIFF
--- a/abnf_to_regexp/main.py
+++ b/abnf_to_regexp/main.py
@@ -140,7 +140,7 @@ def main() -> int:
         "--format",
         help="Output format; for example a single regular expression or a code snippet",
         choices=[entry.value for entry in Format],
-        default=Format.SINGLE_REGEXP,
+        default=Format.SINGLE_REGEXP.value,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
We erroneously passed the default for the `--format` argument as a literal (a reference) instead of the *literal value* (a string).

Fixes #41.