### PR TITLE
Constrain abnf dependency to 2.2.0

### DIFF
--- a/.github/workflows/check-on-pull-request.yml
+++ b/.github/workflows/check-on-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-on-push-to-main.yml
+++ b/.github/workflows/check-on-push-to-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 icontract>=2.5.1,<3
 regex==2021.4.4
-abnf>=2,<3
+abnf>=2.0,<2.3.0
 sortedcontainers>=2,<3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
We have to constrain the dependency `abnf` to <=2.2.0 since 2.3.0 and above fail on Python 3.8. For the moment, we decided to continue supporting Python 3.8, while `abnf` 2.3.0 and above supports only Python
>=3.9.