### PR TITLE
Fix publishing to pypi for pyproject.toml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,7 +7,7 @@ on:
 
   push:
     branches:
-      - '*/fixed-publishing-to-pypi'
+      - '*/Fix-publishing-to-pypi*'
 
 jobs:
   deploy:
@@ -25,12 +25,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
 
     - name: Build and publish
       env:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        python setup.py sdist
+        python -m build
         twine upload dist/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ CHANGELOG
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+1.2.0 (2025-11-08)
+==================
+* Support Python 3.12 and 3.13 (#55)
+* Improve regexp generation for ``#`` (#50)
+* Remove spurious CRLF warning (#48)
+* Improve python-nested regex output for repetition (#45)
+* Fix default for format argument (#42)
+* Constrain abnf dependency to 2.2.0 (#43)
+
+This is a minor version which mainly improves on the compatibility of
+generated regular expressions so that they can be (re-)used across
+more platforms.
+
 1.1.3 (2024-03-22)
 ==================
 * Fix for the case no min. and only max. repetition (#34)

--- a/abnf_to_regexp/__init__.py
+++ b/abnf_to_regexp/__init__.py
@@ -1,7 +1,7 @@
 """Convert ABNF grammars to Python regular expressions."""
 
-# Do not forget to update in setup.py!
-__version__ = "1.1.3"
+# Do not forget to update in pyproject.toml!
+__version__ = "1.2.0"
 __author__ = "Marko Ristin"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abnf-to-regexp"
-version = "1.1.3"
+# Do not forget to update in __init__.py!
+version = "1.2.0"
 description = "Convert ABNF grammars to Python regular expressions."
 readme = "README.rst"
 license = {text = "MIT"}


### PR DESCRIPTION
We moved from setup.py to pyproject.toml, so we have to adapt our publishing pipeline.